### PR TITLE
Added sticky edge padding

### DIFF
--- a/sticky-headers/api/android/sticky-headers.api
+++ b/sticky-headers/api/android/sticky-headers.api
@@ -1,5 +1,5 @@
 public final class me/gingerninja/lazy/GridStickyHeadersKt {
-	public static final fun StickyHeaders (Landroidx/compose/foundation/lazy/grid/LazyGridState;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun StickyHeaders-hGBTI10 (Landroidx/compose/foundation/lazy/grid/LazyGridState;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;FLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class me/gingerninja/lazy/LazyGridInfoProvider : me/gingerninja/lazy/StickyLayoutInfoProvider {
@@ -57,11 +57,11 @@ public final class me/gingerninja/lazy/LazyListItem {
 }
 
 public final class me/gingerninja/lazy/ListStickyHeadersKt {
-	public static final fun StickyHeaders (Landroidx/compose/foundation/lazy/LazyListState;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun StickyHeaders-hGBTI10 (Landroidx/compose/foundation/lazy/LazyListState;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;FLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class me/gingerninja/lazy/StickyHeadersLayoutKt {
-	public static final fun StickyHeadersLayout (Ljava/util/List;Landroidx/compose/foundation/gestures/Orientation;ZLme/gingerninja/lazy/StickyLayoutInfoProvider;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun StickyHeadersLayout-PfoAEA0 (Ljava/util/List;Landroidx/compose/foundation/gestures/Orientation;ZLme/gingerninja/lazy/StickyLayoutInfoProvider;Landroidx/compose/ui/Modifier;FLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class me/gingerninja/lazy/StickyInterval {

--- a/sticky-headers/api/desktop/sticky-headers.api
+++ b/sticky-headers/api/desktop/sticky-headers.api
@@ -1,5 +1,5 @@
 public final class me/gingerninja/lazy/GridStickyHeadersKt {
-	public static final fun StickyHeaders (Landroidx/compose/foundation/lazy/grid/LazyGridState;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun StickyHeaders-hGBTI10 (Landroidx/compose/foundation/lazy/grid/LazyGridState;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;FLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class me/gingerninja/lazy/LazyGridInfoProvider : me/gingerninja/lazy/StickyLayoutInfoProvider {
@@ -57,11 +57,11 @@ public final class me/gingerninja/lazy/LazyListItem {
 }
 
 public final class me/gingerninja/lazy/ListStickyHeadersKt {
-	public static final fun StickyHeaders (Landroidx/compose/foundation/lazy/LazyListState;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun StickyHeaders-hGBTI10 (Landroidx/compose/foundation/lazy/LazyListState;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;FLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class me/gingerninja/lazy/StickyHeadersLayoutKt {
-	public static final fun StickyHeadersLayout (Ljava/util/List;Landroidx/compose/foundation/gestures/Orientation;ZLme/gingerninja/lazy/StickyLayoutInfoProvider;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun StickyHeadersLayout-PfoAEA0 (Ljava/util/List;Landroidx/compose/foundation/gestures/Orientation;ZLme/gingerninja/lazy/StickyLayoutInfoProvider;Landroidx/compose/ui/Modifier;FLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class me/gingerninja/lazy/StickyInterval {

--- a/sticky-headers/src/commonMain/kotlin/me/gingerninja/lazy/GridStickyHeaders.kt
+++ b/sticky-headers/src/commonMain/kotlin/me/gingerninja/lazy/GridStickyHeaders.kt
@@ -26,8 +26,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import kotlin.jvm.JvmInline
 
 /**
@@ -92,6 +94,7 @@ value class LazyGridItem(private val value: LazyGridItemInfo) {
  * @param state the [LazyGridState] of the grid
  * @param key key factory function for the sticky items
  * @param modifier [Modifier] applied to the container of the sticky items
+ * @param stickyEdgePadding the padding applied to the sticky items on the edge where they stick to
  * @param content sticky item content
  */
 @Composable
@@ -100,6 +103,7 @@ fun <T : Any> StickyHeaders(
     key: (item: List<LazyGridItem>) -> T?,
     // contentType: (item: LazyListItem) -> Any? = { null },
     modifier: Modifier = Modifier,
+    stickyEdgePadding: Dp = 0.dp,
     content: @Composable (stickyInterval: StickyInterval<T>) -> Unit,
 ) {
     val keyFactory = rememberUpdatedState(key)
@@ -201,6 +205,7 @@ fun <T : Any> StickyHeaders(
         reverseLayout = reverseLayout,
         layoutInfoProvider = remember(state) { LazyGridInfoProvider(state) },
         modifier = modifier,
+        stickyEdgePadding = stickyEdgePadding,
         content = content,
     )
 }

--- a/sticky-headers/src/commonMain/kotlin/me/gingerninja/lazy/ListStickyHeaders.kt
+++ b/sticky-headers/src/commonMain/kotlin/me/gingerninja/lazy/ListStickyHeaders.kt
@@ -25,6 +25,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import kotlin.jvm.JvmInline
 
 /**
@@ -94,6 +96,7 @@ value class LazyListItem(private val value: LazyListItemInfo) {
  * @param state the [LazyListState] of the list
  * @param key key factory function for the sticky items
  * @param modifier [Modifier] applied to the container of the sticky items
+ * @param stickyEdgePadding the padding applied to the sticky items on the edge where they stick to
  * @param content sticky item content
  */
 @Composable
@@ -102,6 +105,7 @@ fun <T : Any> StickyHeaders(
     key: (item: LazyListItem) -> T?,
     // contentType: (item: LazyListItem) -> Any? = { null },
     modifier: Modifier = Modifier,
+    stickyEdgePadding: Dp = 0.dp,
     content: @Composable (stickyInterval: StickyInterval<T>) -> Unit,
 ) {
     val keyFactory = rememberUpdatedState(key)
@@ -164,6 +168,7 @@ fun <T : Any> StickyHeaders(
         reverseLayout = reverseLayout,
         layoutInfoProvider = remember(state) { LazyListInfoProvider(state) },
         modifier = modifier,
+        stickyEdgePadding = stickyEdgePadding,
         content = content,
     )
 }

--- a/sticky-headers/src/commonMain/kotlin/me/gingerninja/lazy/StickyHeadersLayout.kt
+++ b/sticky-headers/src/commonMain/kotlin/me/gingerninja/lazy/StickyHeadersLayout.kt
@@ -24,7 +24,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
 
 /**
  * Provides basic info about the layout that will be used by [StickyHeadersLayout] when placing the
@@ -67,6 +69,7 @@ interface StickyLayoutInfoProvider {
  * laid out in the reverse order.
  * @param layoutInfoProvider basic info provider about the visible items and their container
  * @param modifier [Modifier] applied to the container of the sticky items
+ * @param stickyEdgePadding the padding applied to the sticky items on the edge where they stick to
  * @param content sticky item content
  */
 @Composable
@@ -76,6 +79,7 @@ fun <T : Any> StickyHeadersLayout(
     reverseLayout: Boolean,
     layoutInfoProvider: StickyLayoutInfoProvider,
     modifier: Modifier = Modifier,
+    stickyEdgePadding: Dp = 0.dp,
     content: @Composable (stickyInterval: StickyInterval<T>) -> Unit,
 ) {
     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
@@ -112,24 +116,30 @@ fun <T : Any> StickyHeadersLayout(
 
                             val direction = if (switchDirection) -1f else 1f
 
+                            val stickyPadding = stickyEdgePadding.roundToPx()
+
                             if (itemOffset == null) {
                                 // don't show the item if it's not visible anymore
                                 alpha = 0f
                             } else {
+                                val diff = nextOffset - spacing + beforePadding - stickyPadding
+
                                 if (orientation == Orientation.Vertical) {
-                                    val y = (nextOffset - spacing - size.height + beforePadding)
-                                        .coerceAtMost(0f)
+                                    val y = (diff - size.height).coerceAtMost(0f)
                                     val offset =
                                         (itemOffset + beforePadding).coerceAtLeast(0)
 
-                                    translationY = (offset + y) * direction
+                                    val inset = (stickyPadding - offset).coerceAtLeast(0)
+
+                                    translationY = (offset + y + inset) * direction
                                 } else {
-                                    val x = (nextOffset - spacing - size.width + beforePadding)
-                                        .coerceAtMost(0f)
+                                    val x = (diff - size.width).coerceAtMost(0f)
                                     val offset =
                                         (itemOffset + beforePadding).coerceAtLeast(0)
 
-                                    translationX = (offset + x) * direction
+                                    val inset = (stickyPadding - offset).coerceAtLeast(0)
+
+                                    translationX = (offset + x + inset) * direction
                                 }
                             }
                         },


### PR DESCRIPTION
The sticky edge padding can be used for providing an extra padding that is applied to the currently sticking item.

This is a feature requested in #2 